### PR TITLE
 implement reading block by a given file number

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 client/sipadll.go
 client/sipasec.go
 client/openssl.go
+.idea/

--- a/lib/others/blockdb/blockdb.go
+++ b/lib/others/blockdb/blockdb.go
@@ -104,7 +104,7 @@ func (db *BlockDB) FetchNextBlock() (bl []byte, e error) {
 
 func lsb2uint(lt []byte) (res uint64) {
 	for i:=0; i<len(lt); i++ {
-		res |= (uint64(lt[i]) << uint(i*8))
+		res |= uint64(lt[i]) << uint(i*8)
 	}
 	return
 }

--- a/lib/others/blockdb/blockdb.go
+++ b/lib/others/blockdb/blockdb.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"bytes"
 	"errors"
+	"io"
 )
 
 
@@ -78,7 +79,7 @@ func (db *BlockDB)readOneBlock() (res []byte, e error) {
 	fpos, _ := db.f.Seek(0, 1)
 	res, e = readBlockFromFile(db.f, db.magic[:])
 	if e != nil {
-		db.f.Seek(int64(fpos), os.SEEK_SET) // restore the original position
+		db.f.Seek(int64(fpos), io.SeekStart) // restore the original position
 		return
 	}
 	return

--- a/lib/others/blockdb/blockdb.go
+++ b/lib/others/blockdb/blockdb.go
@@ -85,6 +85,18 @@ func (db *BlockDB)readOneBlock() (res []byte, e error) {
 	return
 }
 
+func (db *BlockDB) GetBlockByFileNumber(fileNumber uint32) ([]byte, error) {
+	db.f.Close()
+	f, e := os.Open(idx2fname(db.dir, fileNumber))
+	if e != nil {
+		return nil, e
+	}
+	db.f = f
+	db.currfileidx = fileNumber
+	block, err := db.readOneBlock()
+	return block, err
+}
+
 func (db *BlockDB) FetchNextBlock() (bl []byte, e error) {
 	if db.f == nil {
 		println("DB file not open - this should never happen")


### PR DESCRIPTION
In some use cases the DB file number is known, so the block can be read directly
without iterating all the files via GetNextBlock().